### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/multilingual_survey/urls.py
+++ b/multilingual_survey/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
 from multilingual_survey import views
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^(?P<slug>[\w-]+)/$', views.survey_form, name='form'),
     url(r'^success/(?P<uuid>\w+)/$', views.survey_success, name='success'),
-)
+]


### PR DESCRIPTION
Salut Aymeric,
Small change for compatibility, going forward with Django 1.10.1 where from django.conf.urls patterns is no longer supported.
